### PR TITLE
add pre- and post-link text insertion with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ to
 ## Parameters
 
 |   Attributes   |  Type  | Required |             Default            | Description                                                                      |
-|:--=-----------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
+|:--------------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
 |     hosts      |  Array |    No    |              []                | Site hostname(s) to detect external links.                                       |
 |     host       | String |    No    |              null              | Single site hostname( to detect external links (ignored if hosts is provided)    |
 |    target      | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ to
 
 |   Attributes   |  Type  | Required |             Default            | Description                                                                      |
 |:--------------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
-|     hosts      |  Array |    No    |              []                | Site hostname(s) to detect external links.                                       |
-|     host       | String |    No    |              null              | Single site hostname( to detect external links (ignored if hosts is provided)    |
+|     hosts      |  Array |   Yes    |              []                | Site hostname(s) to detect external links.                                       |
 |    target      | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |
 |      rel       | String |    No    | `nofollow noreferrer noopener` | Specifies the relationship between the current document and the linked document. |
 | externalOnly   | String |    No    |              true              | Prepend / append text only to external links.                                    |

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Or with text insertions...
 
 ```javascript
 md.use(remarkableExternalLink, {
-  'preOutside': '[',
-  'preInside': '-=',
-  'postInside': '=-',
-  'postOutside': '] (ext)',
+  'beforeLink': '[',
+  'beforeLinkText': '-=',
+  'afterLinkText': '=-',
+  'afterLink': '] (ext)',
 });
 
 
@@ -93,17 +93,17 @@ to
 
 ## Parameters
 
-| Attributes  |  Type  | Required |             Default            | Description                                                                      |
-|:-----------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
-|    hosts    |  Array |    No    |              []                | Site hostname(s) to detect external links.                                       |
-|    host     | String |    No    |              null              | Single site hostname( to detect external links (ignored if hosts is provided)    |
-|   target    | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |
-|     rel     | String |    No    | `nofollow noreferrer noopener` | Specifies the relationship between the current document and the linked document. |
-| textExtOnly | String |    No    |              true              | Prepend / append text only to external links.                                    |
-|  preOutside | String |    No    |              null              | Specifies HTML to be inserted before an external link.                           |
-|  preInside  | String |    No    |              null              | Specifies HTML to be inserted at the start of the text within an external link.  |
-|  postInside | String |    No    |              null              | Specifies HTML to be inserted at the end of the text within an external link.    |
-| postOutside | String |    No    |              null              | Specifies HTML to be inserted after an external link.                            |
+|   Attributes   |  Type  | Required |             Default            | Description                                                                      |
+|:--=-----------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
+|     hosts      |  Array |    No    |              []                | Site hostname(s) to detect external links.                                       |
+|     host       | String |    No    |              null              | Single site hostname( to detect external links (ignored if hosts is provided)    |
+|    target      | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |
+|      rel       | String |    No    | `nofollow noreferrer noopener` | Specifies the relationship between the current document and the linked document. |
+| externalOnly   | String |    No    |              true              | Prepend / append text only to external links.                                    |
+|   beforeLink   | String |    No    |              null              | Specifies HTML to be inserted before an external link.                           |
+| beforeLinkText | String |    No    |              null              | Specifies HTML to be inserted at the start of the text within an external link.  |
+| afterLinkText  | String |    No    |              null              | Specifies HTML to be inserted at the end of the text within an external link.    |
+|    afterLink   | String |    No    |              null              | Specifies HTML to be inserted after an external link.                            |
 
 [npm-image]: https://img.shields.io/npm/v/remarkable-external-link.svg
 [npm-url]: https://www.npmjs.com/package/remarkable-external-link

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status][travis-image]][travis-url]
 [![AppVeyor Build Status][appveyor-image]][appveyor-url]
 
-[Remarkable](https://www.npmjs.com/package/remarkable) plugin adds `target` and `rel` attributes on external links.
+[Remarkable](https://www.npmjs.com/package/remarkable) plugin adds `target` and `rel` attributes on external links plus supports insertion of text before and after each link.
 
 ## Install
 
@@ -63,13 +63,47 @@ const siteConfig = {
 }
 ```
 
+Or with text insertions...
+
+```javascript
+md.use(remarkableExternalLink, {
+  'preOutside': '[',
+  'preInside': '-=',
+  'postInside': '=-',
+  'postOutside': '] (ext)',
+});
+
+
+const testString = 'This is an [Example](http://example.com) link';
+console.log(md.render(testString));
+
+// Expect
+// '<p>This is a [<a href="http://example.com">-= link =-</a>] <sub>(ext)</sub> in markdown.</p>\n'
+```
+
+which will change the HTML display from
+
+> <p>This is a <a href="http://example.com">link</a> in markdown.</p>
+
+to
+
+> <p>This is a [<a href="http://example.com">-= link =-</a>] (ext) in markdown.</p>
+
+
+
 ## Parameters
 
-| Attributes |  Type  | Required |             Default            | Description                                                                      |
-|:----------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
-|    hosts   |  Array |    Yes   |                                | Site hostname(s) to detect external links.                                       |
-|   target   | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |
-|     rel    | String |    No    | `nofollow noreferrer noopener` | Specifies the relationship between the current document and the linked document. |
+| Attributes  |  Type  | Required |             Default            | Description                                                                      |
+|:-----------:|:------:|:--------:|:------------------------------:|----------------------------------------------------------------------------------|
+|    hosts    |  Array |    No    |              []                | Site hostname(s) to detect external links.                                       |
+|    host     | String |    No    |              null              | Single site hostname( to detect external links (ignored if hosts is provided)    |
+|   target    | String |    No    |            `_blank`            | Specifies where to open the linked document.                                     |
+|     rel     | String |    No    | `nofollow noreferrer noopener` | Specifies the relationship between the current document and the linked document. |
+| textExtOnly | String |    No    |              true              | Prepend / append text only to external links.                                    |
+|  preOutside | String |    No    |              null              | Specifies HTML to be inserted before an external link.                           |
+|  preInside  | String |    No    |              null              | Specifies HTML to be inserted at the start of the text within an external link.  |
+|  postInside | String |    No    |              null              | Specifies HTML to be inserted at the end of the text within an external link.    |
+| postOutside | String |    No    |              null              | Specifies HTML to be inserted after an external link.                            |
 
 [npm-image]: https://img.shields.io/npm/v/remarkable-external-link.svg
 [npm-url]: https://www.npmjs.com/package/remarkable-external-link

--- a/index.js
+++ b/index.js
@@ -55,18 +55,16 @@ function remarkableExternalLink(md, options) {
         }
 
         linkExternalStack.push(externalLink);
-        result = externalLink || !finalConfig.externalOnly
-            ? (options.beforeLink || "") + result + (options.beforeLinkText || "")
-            : result;
+        if (externalLink || !finalConfig.externalOnly)
+          result = (options.beforeLink || "") + result + (options.beforeLinkText || "");
         return result;
     };
 
     md.renderer.rules.link_close = function (tokens, idx, ...args) {
       let result = defaultCloseRender(tokens, idx, ...args);
       const externalLink = linkExternalStack.pop();
-      result = externalLink || !finalConfig.externalOnly
-          ? (options.afterLinkText || "") + result + (options.afterLink || "")
-          : result;
+      if (externalLink || !finalConfig.externalOnly)
+        result = (options.afterLinkText || "") + result + (options.afterLink || "");
       return result;
     }
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function remarkableExternalLink(md, options) {
     const defaultOptions = {
         'rel': 'nofollow noreferrer noopener',
         'target': '_blank',
-        textExtOnly: true,
+        externalOnly: true,
     };
     const defaultOpenRender = md.renderer.rules.link_open;
     const defaultCloseRender = md.renderer.rules.link_close;
@@ -55,8 +55,8 @@ function remarkableExternalLink(md, options) {
         }
 
         linkExternalStack.push(externalLink);
-        result = externalLink || !finalConfig.textExtOnly
-            ? (options.preOutside || "") + result + (options.preInside || "")
+        result = externalLink || !finalConfig.externalOnly
+            ? (options.beforeLink || "") + result + (options.beforeLinkText || "")
             : result;
         return result;
     };
@@ -64,8 +64,8 @@ function remarkableExternalLink(md, options) {
     md.renderer.rules.link_close = function (tokens, idx, ...args) {
       let result = defaultCloseRender(tokens, idx, ...args);
       const externalLink = linkExternalStack.pop();
-      result = externalLink || !finalConfig.textExtOnly
-          ? (options.postInside || "") + result + (options.postOutside || "")
+      result = externalLink || !finalConfig.externalOnly
+          ? (options.afterLinkText || "") + result + (options.afterLink || "")
           : result;
       return result;
     }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const url_1 = require("url");
-
 const linkExternalStack = [];
-
 function remarkableExternalLink(md, options) {
     const configHosts = [];
     const defaultOptions = {
         'rel': 'nofollow noreferrer noopener',
         'target': '_blank',
-        externalOnly: true,
+        'externalOnly': true,
     };
     const defaultOpenRender = md.renderer.rules.link_open;
     const defaultCloseRender = md.renderer.rules.link_close;
@@ -33,7 +31,6 @@ function remarkableExternalLink(md, options) {
             configHosts.push(finalConfig.host);
         }
     }
-
     md.renderer.rules.link_open = function (tokens, idx, ...args) {
         let result = defaultOpenRender(tokens, idx, ...args);
         let externalLink = false;
@@ -48,24 +45,22 @@ function remarkableExternalLink(md, options) {
             }
             if (origin) {
                 if (configHosts.length === 0 || configHosts.indexOf(origin) === -1) {
-                    externalLink = true;
                     result = result.replace('>', ' target="' + finalConfig.target + '" rel="' + finalConfig.rel + '">');
+                    externalLink = true;
                 }
             }
         }
-
         linkExternalStack.push(externalLink);
         if (externalLink || !finalConfig.externalOnly)
-          result = (options.beforeLink || "") + result + (options.beforeLinkText || "");
+            result = (options.beforeLink || "") + result + (options.beforeLinkText || "");
         return result;
     };
-
     md.renderer.rules.link_close = function (tokens, idx, ...args) {
-      let result = defaultCloseRender(tokens, idx, ...args);
-      const externalLink = linkExternalStack.pop();
-      if (externalLink || !finalConfig.externalOnly)
-        result = (options.afterLinkText || "") + result + (options.afterLink || "");
-      return result;
-    }
+        let result = defaultCloseRender(tokens, idx, ...args);
+        const externalLink = linkExternalStack.pop();
+        if (externalLink || !finalConfig.externalOnly)
+            result = (options.afterLinkText || "") + result + (options.afterLink || "");
+        return result;
+    };
 }
 exports.default = remarkableExternalLink;

--- a/test/link.js
+++ b/test/link.js
@@ -41,11 +41,11 @@ describe('Test `external` links', () => {
         'http://example.com',
         'http://test.example.com'
       ],
-      'textExtOnly': true,
-      'preOutside': '[',
-      'preInside': '-= ',
-      'postInside': ' =-',
-      'postOutside': '] (ext)',
+      'externalOnly': true,
+      'beforeLink': '[',
+      'beforeLinkText': '-= ',
+      'afterLinkText': ' =-',
+      'afterLink': '] (ext)',
     });
 
     assert.strictEqual(md.render(testString), expectedOutput);
@@ -60,11 +60,11 @@ describe('Test `external` links', () => {
         'http://example.com',
         'http://test.example.com'
       ],
-      'textExtOnly': false,
-      'preOutside': '[',
-      'preInside': '-= ',
-      'postInside': ' =-',
-      'postOutside': '] (ext)',
+      'externalOnly': false,
+      'beforeLink': '[',
+      'beforeLinkText': '-= ',
+      'afterLinkText': ' =-',
+      'afterLink': '] (ext)',
     });
 
     assert.strictEqual(md.render(testString), expectedOutput);

--- a/test/link.js
+++ b/test/link.js
@@ -31,4 +31,43 @@ describe('Test `external` links', () => {
 
     assert.strictEqual(md.render(testString), expectedOutput);
   });
+
+  it('Test text insertion before external links', () => {
+    const expectedOutput = `<p>This is an <a href="http://example.com">Example</a> link, [<a href="https://google.com" target="_blank" rel="nofollow noreferrer noopener">-= Google =-</a>] (ext) link, [<a href="https://facebook.com" target="_blank" rel="nofollow noreferrer noopener">-= Facebook =-</a>] (ext) link, <a href="http://test.example.com/">Test Example</a> link, [<a href="http://test2.example.com/" target="_blank" rel="nofollow noreferrer noopener">-= Test2 Example =-</a>] (ext) link and <a href="/docs/concept/">Relative</a> link.</p>\n`;
+    const md = new Remarkable();
+
+    md.use(remarkableExternalLink, {
+      'hosts': [
+        'http://example.com',
+        'http://test.example.com'
+      ],
+      'textExtOnly': true,
+      'preOutside': '[',
+      'preInside': '-= ',
+      'postInside': ' =-',
+      'postOutside': '] (ext)',
+    });
+
+    assert.strictEqual(md.render(testString), expectedOutput);
+  });
+
+  it('Test text insertion before all links', () => {
+    const expectedOutput = `<p>This is an [<a href="http://example.com">-= Example =-</a>] (ext) link, [<a href="https://google.com" target="_blank" rel="nofollow noreferrer noopener">-= Google =-</a>] (ext) link, [<a href="https://facebook.com" target="_blank" rel="nofollow noreferrer noopener">-= Facebook =-</a>] (ext) link, [<a href="http://test.example.com/">-= Test Example =-</a>] (ext) link, [<a href="http://test2.example.com/" target="_blank" rel="nofollow noreferrer noopener">-= Test2 Example =-</a>] (ext) link and [<a href="/docs/concept/">-= Relative =-</a>] (ext) link.</p>\n`;
+    const md = new Remarkable();
+
+    md.use(remarkableExternalLink, {
+      'hosts': [
+        'http://example.com',
+        'http://test.example.com'
+      ],
+      'textExtOnly': false,
+      'preOutside': '[',
+      'preInside': '-= ',
+      'postInside': ' =-',
+      'postOutside': '] (ext)',
+    });
+
+    assert.strictEqual(md.render(testString), expectedOutput);
+  });
+
 });

--- a/test/runkitExample.js
+++ b/test/runkitExample.js
@@ -32,10 +32,10 @@ const md = new Remarkable();
   const testString = 'This is an [Example](http://example.com) link';
 
   md.use(remarkableExternalLink, {
-    'preOutside': '[',
-    'preInside': '-= ',
-    'postInside': ' =-',
-    'postOutside': ']',
+    'beforeLink': '[',
+    'beforeLinkText': '-= ',
+    'afterLinkText': ' =-',
+    'afterLink': ']',
   });
 
   const output = md.render(testString);
@@ -44,4 +44,5 @@ const md = new Remarkable();
   } else {
     console.error('Text insertion Test Failed.');
   }
-}
+}afterLinkText
+afterLink

--- a/test/runkitExample.js
+++ b/test/runkitExample.js
@@ -2,20 +2,46 @@ const { Remarkable } = require('remarkable');
 const remarkableExternalLink = require('remarkable-external-link').default;
 
 const md = new Remarkable();
-const expectedOutput = '<p>This is an <a href="http://example.com">Example</a> link, <a href="https://google.com" target="_blank" rel="nofollow noreferrer noopener">Google</a> link, <a href="https://facebook.com" target="_blank" rel="nofollow noreferrer noopener">Facebook</a> link, <a href="http://test.example.com/">Test Example</a> link, <a href="http://test2.example.com/" target="_blank" rel="nofollow noreferrer noopener">Test2 Example</a> link and <a href="/docs/concept/">Relative</a> link.</p>';
-const matchString = new RegExp(expectedOutput, 'u');
-const testString = 'This is an [Example](http://example.com) link, [Google](https://google.com) link, [Facebook](https://facebook.com) link, [Test Example](http://test.example.com/) link, [Test2 Example](http://test2.example.com/) link and [Relative](/docs/concept/) link.';
 
-md.use(remarkableExternalLink, {
-  'hosts': [
-    'http://example.com',
-    'http://test.example.com'
-  ]
-});
+// Test 1 - core
+{
+  const expectedOutput = '<p>This is an <a href="http://example.com">Example</a> link, <a href="https://google.com" target="_blank" rel="nofollow noreferrer noopener">Google</a> link, <a href="https://facebook.com" target="_blank" rel="nofollow noreferrer noopener">Facebook</a> link, <a href="http://test.example.com/">Test Example</a> link, <a href="http://test2.example.com/" target="_blank" rel="nofollow noreferrer noopener">Test2 Example</a> link and <a href="/docs/concept/">Relative</a> link.</p>';
+  const matchString = new RegExp(expectedOutput, 'u');
+  const testString = 'This is an [Example](http://example.com) link, [Google](https://google.com) link, [Facebook](https://facebook.com) link, [Test Example](http://test.example.com/) link, [Test2 Example](http://test2.example.com/) link and [Relative](/docs/concept/) link.';
 
-const output = md.render(testString);
-if (output.match(matchString)) {
-  console.log('Domain and subdomains Test Passed.');
-} else {
-  console.error('Domain and subdomains Test Failed.');
+  md.use(remarkableExternalLink, {
+    'hosts': [
+      'http://example.com',
+      'http://test.example.com'
+    ]
+  });
+
+  const output = md.render(testString);
+  if (output.match(matchString)) {
+    console.log('Domain and subdomains Test Passed.');
+  } else {
+    console.error('Domain and subdomains Test Failed.');
+  }
+}
+
+
+// Test 2 - text insertions
+{
+  const expectedOutput = '<p>This is an [<a href="http://example.com">-= Example =-</a>] link</p>';
+  const matchString = new RegExp(expectedOutput, 'u');
+  const testString = 'This is an [Example](http://example.com) link';
+
+  md.use(remarkableExternalLink, {
+    'preOutside': '[',
+    'preInside': '-= ',
+    'postInside': ' =-',
+    'postOutside': ']',
+  });
+
+  const output = md.render(testString);
+  if (output.match(matchString)) {
+    console.log('Text insertion Test Passed.');
+  } else {
+    console.error('Text insertion Test Failed.');
+  }
 }

--- a/test/runkitExample.js
+++ b/test/runkitExample.js
@@ -44,5 +44,4 @@ const md = new Remarkable();
   } else {
     console.error('Text insertion Test Failed.');
   }
-}afterLinkText
-afterLink
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,4 +17,5 @@ export type configOptions = {
 export type defaultOptions = {
   rel: string;
   target: string;
+  externalOnly: boolean;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,11 @@ export type configOptions = {
   host?: string;
   target?: string;
   rel?: string;
+  textExtOnly?: boolean;
+  preOutside?: string;
+  preInside?: string;
+  postInside?: string;
+  postOutside?: string;
 };
 
 export type defaultOptions = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,11 +7,11 @@ export type configOptions = {
   host?: string;
   target?: string;
   rel?: string;
-  textExtOnly?: boolean;
-  preOutside?: string;
-  preInside?: string;
-  postInside?: string;
-  postOutside?: string;
+  externalOnly?: boolean;
+  beforeLink?: string;
+  beforeLinkText?: string;
+  afterLinkText?: string;
+  afterLink?: string;
 };
 
 export type defaultOptions = {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -17,11 +17,11 @@ const singleHost = {
 };
 
 const insertText = {
-  'textExtOnly': false,
-  'preOutside': '[',
-  'preInside': '-= ',
-  'postInside': ' =-',
-  'postOutside': '] (ext)',
+  'externalOnly': false,
+  'beforeLink': '[',
+  'beforeLinkText': '-= ',
+  'afterLinkText': ' =-',
+  'afterLink': '] (ext)',
 };
 
 if (singleHost) {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -16,6 +16,14 @@ const singleHost = {
   'hosts': ['http://example.com']
 };
 
+const insertText = {
+  'textExtOnly': false,
+  'preOutside': '[',
+  'preInside': '-= ',
+  'postInside': ' =-',
+  'postOutside': '] (ext)',
+};
+
 if (singleHost) {
   md.use(remarkableExternalLink, singleHost);
   md.render(testString);
@@ -23,5 +31,10 @@ if (singleHost) {
 
 if (multipleHosts) {
   md.use(remarkableExternalLink, multipleHosts);
+  md.render(testString);
+}
+
+if (insertText) {
+  md.use(remarkableExternalLink, insertText);
   md.render(testString);
 }


### PR DESCRIPTION
Hi,

I needed to add 🔗  link character to external links or the link SVG https://commons.wikimedia.org/wiki/File:External_link_font_awesome.svg 

The extension should be backwards compatible with your release. It adds 5 parameters for adding text (a) before / after and (b) inside / outside the <a> tag (c) on external or all links.

Up to you if you want to add it to your already-useful package.

-Andrew